### PR TITLE
cleanup pre_processor.rb

### DIFF
--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -12,7 +12,9 @@ module PragmaticTokenizer
       shift_inverted_question_mark!
       shift_inverted_exclamation!
       shift_exclamation!
-      shift_ellipse!
+      shift_ellipse_three_dots!
+      shift_ellipse_two_dots!
+      shift_horizontal_ellipsis!
       shift_no_space_mention!
       shift_not_equals!
       shift_special_quotes!
@@ -56,10 +58,16 @@ module PragmaticTokenizer
         @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! '.freeze)
       end
 
-      def shift_ellipse!
-        @text.gsub!(/(\.\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
-        @text.gsub!(/(\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+      def shift_horizontal_ellipsis!
         @text.gsub!(/(…+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+      end
+
+      def shift_ellipse_two_dots!
+        @text.gsub!(/(\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+      end
+
+      def shift_ellipse_three_dots!
+        @text.gsub!(/(\.\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_no_space_mention!
@@ -120,11 +128,17 @@ module PragmaticTokenizer
       end
 
       def convert_dbl_quotes!
-        # Convert left double quotes to special character
+        replace_left_double_quotes!
+        replace_remaining_double_quotes!
+      end
+
+      def replace_left_double_quotes!
         @text.gsub!(/''(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
         @text.gsub!(/"(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
         @text.gsub!(/“(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['“'.freeze] + ' '.freeze)
-        # Convert remaining quotes to special character
+      end
+
+      def replace_remaining_double_quotes!
         @text.gsub!(/"/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
         @text.gsub!(/''/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
         @text.gsub!(/”/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'.freeze] + ' '.freeze)

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -31,7 +31,7 @@ module PragmaticTokenizer
       convert_apostrophe_s!
       shift_beginning_hyphen!
       shift_ending_hyphen!
-      @text.squeeze(' ')
+      @text.squeeze(' '.freeze)
     end
 
     private

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -6,143 +6,148 @@ module PragmaticTokenizer
     end
 
     def pre_process(text:)
-      shift_comma(text)
-      shift_multiple_dash(text)
-      shift_upsidedown_question_mark(text)
-      shift_upsidedown_exclamation(text)
-      shift_exclamation(text)
-      shift_ellipse(text)
-      shift_no_space_mention(text)
-      shift_not_equals(text)
-      shift_special_quotes(text)
-      shift_colon(text)
-      shift_bracket(text)
-      shift_semicolon(text)
-      shift_percent(text)
-      shift_caret(text)
-      shift_hashtag(text)
-      shift_ampersand(text)
-      shift_vertical_bar(text)
-      convert_dbl_quotes(text)
-      convert_sgl_quotes(text)
-      convert_apostrophe_s(text)
-      shift_beginning_hyphen(text)
-      shift_ending_hyphen(text)
-      text.squeeze(' ')
+      @text = text
+      shift_comma
+      shift_multiple_dash
+      shift_upsidedown_question_mark
+      shift_upsidedown_exclamation
+      shift_exclamation
+      shift_ellipse
+      shift_no_space_mention
+      shift_not_equals
+      shift_special_quotes
+      shift_colon
+      shift_bracket
+      shift_semicolon
+      shift_percent
+      shift_caret
+      shift_hashtag
+      shift_ampersand
+      shift_vertical_bar
+      convert_dbl_quotes
+      convert_sgl_quotes
+      convert_apostrophe_s
+      shift_beginning_hyphen
+      shift_ending_hyphen
+      @text.squeeze(' ')
     end
 
     private
 
-      def shift_comma(text)
-        # Shift commas off everything but numbers
-        text.gsub!(/,(?!\d)/o, ' , ') || text
-        text.gsub!(/(?<=\D),(?=\S+)/, ' , ') || text
+      # Shift commas off everything but numbers
+      def shift_comma
+        @text.gsub!(/,(?!\d)/o, ' , ')
+        @text.gsub!(/(?<=\D),(?=\S+)/, ' , ')
       end
 
-      def shift_multiple_dash(text)
-        text.gsub!(/--+/o, ' - ') || text
+      def shift_multiple_dash
+        @text.gsub!(/--+/o, ' - ')
       end
 
-      def shift_upsidedown_question_mark(text)
-        text.gsub!(/¿/, ' ¿ ') || text
+      def shift_upsidedown_question_mark
+        @text.gsub!(/¿/, ' ¿ ')
       end
 
-      def shift_upsidedown_exclamation(text)
-        text.gsub!(/¡/, ' ¡ ') || text
+      def shift_upsidedown_exclamation
+        @text.gsub!(/¡/, ' ¡ ')
       end
 
-      def shift_exclamation(text)
-        text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! ') || text
+      def shift_exclamation
+        @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! ')
       end
 
-      def shift_ellipse(text)
-        text.gsub!(/(\.\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' } || text
-        text.gsub!(/(\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' } || text
-        text.gsub!(/(…+)/o) { ' ' + Regexp.last_match(1) + ' ' } || text
+      def shift_ellipse
+        @text.gsub!(/(\.\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
+        @text.gsub!(/(\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
+        @text.gsub!(/(…+)/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_no_space_mention(text)
-        text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. ') || text
+      def shift_no_space_mention
+        @text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. ')
       end
 
-      def shift_not_equals(text)
-        text.gsub!(/≠/, ' ≠ ') || text
+      def shift_not_equals
+        @text.gsub!(/≠/, ' ≠ ')
       end
 
-      def shift_special_quotes(text)
-        text.gsub!(/«/, ' « ') || text
-        text.gsub!(/»/, ' » ') || text
-        text.gsub!(/„/, ' „ ') || text
-        text.gsub!(/“/, ' “ ') || text
+      def shift_special_quotes
+        @text.gsub!(/«/, ' « ')
+        @text.gsub!(/»/, ' » ')
+        @text.gsub!(/„/, ' „ ')
+        @text.gsub!(/“/, ' “ ')
       end
 
-      def shift_colon(text)
-        return text unless text.include?(':') &&
-                           (text.partition(':').last[0] !~ /\A\d+/ ||
-                           text.partition(':').first[-1] !~ /\A\d+/)
+      def shift_colon
+        return unless may_shift_colon?
         # Ignore web addresses
-        text.gsub!(/(?<=[http|https]):(?=\/\/)/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP[":"]) || text
-        text.gsub!(/:/o, ' :') || text
-        text.gsub!(/(?<=\s):(?=\#)/, ': ') || text
+        @text.gsub!(/(?<=[http|https]):(?=\/\/)/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP[":"])
+        @text.gsub!(/:/o, ' :')
+        @text.gsub!(/(?<=\s):(?=\#)/, ': ')
       end
 
-      def shift_bracket(text)
-        text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' ' } || text
+      def may_shift_colon?
+        return false unless @text.include?(':')
+        partitions = @text.partition(':')
+        partitions.last[0] !~ /\A\d+/ || partitions.first[-1] !~ /\A\d+/
       end
 
-      def shift_semicolon(text)
-        text.gsub!(/([;])/o) { ' ' + Regexp.last_match(1) + ' ' } || text
+      def shift_bracket
+        @text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_percent(text)
-        text.gsub!(/(?<=\D)%(?=\d+)/, ' %') || text
+      def shift_semicolon
+        @text.gsub!(/([;])/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_caret(text)
-        text.gsub!(/\^/, ' ^ ') || text
+      def shift_percent
+        @text.gsub!(/(?<=\D)%(?=\d+)/, ' %')
       end
 
-      def shift_hashtag(text)
-        text.gsub!(/(?<=\S)(#|＃)(?=\S)/, ' \1\2') || text
+      def shift_caret
+        @text.gsub!(/\^/, ' ^ ')
       end
 
-      def shift_ampersand(text)
-        text.gsub!(/\&/, ' & ') || text
+      def shift_hashtag
+        @text.gsub!(/(?<=\S)(#|＃)(?=\S)/, ' \1\2')
       end
 
-      def shift_vertical_bar(text)
-        text.gsub!(/\|/, ' | ') || text
+      def shift_ampersand
+        @text.gsub!(/\&/, ' & ')
       end
 
-      def convert_dbl_quotes(text)
+      def shift_vertical_bar
+        @text.gsub!(/\|/, ' | ')
+      end
+
+      def convert_dbl_quotes
         # Convert left double quotes to special character
-        text.gsub!(/''(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ') || text
-        text.gsub!(/"(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ') || text
-        text.gsub!(/“(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['“'] + ' ') || text
+        @text.gsub!(/''(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
+        @text.gsub!(/"(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
+        @text.gsub!(/“(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['“'] + ' ')
         # Convert remaining quotes to special character
-        text.gsub!(/"/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ') || text
-        text.gsub!(/''/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ') || text
-        text.gsub!(/”/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'] + ' ') || text
+        @text.gsub!(/"/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
+        @text.gsub!(/''/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
+        @text.gsub!(/”/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'] + ' ')
       end
 
-      def convert_sgl_quotes(text)
+      def convert_sgl_quotes
         if defined? @language::SingleQuotes
-          @language::SingleQuotes.new.handle_single_quotes(text)
+          @language::SingleQuotes.new.handle_single_quotes(@text)
         else
-          PragmaticTokenizer::Languages::Common::SingleQuotes.new.handle_single_quotes(text)
+          PragmaticTokenizer::Languages::Common::SingleQuotes.new.handle_single_quotes(@text)
         end
       end
 
-      def convert_apostrophe_s(text)
-        text.gsub!(/\s\u{0301}(?=s(\s|\z))/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['`']) || text
+      def convert_apostrophe_s
+        @text.gsub!(/\s\u{0301}(?=s(\s|\z))/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['`'])
       end
 
-      def shift_beginning_hyphen(text)
-        text.gsub!(/\s+-/, ' - ') || text
+      def shift_beginning_hyphen
+        @text.gsub!(/\s+-/, ' - ')
       end
 
-      def shift_ending_hyphen(text)
-        text.gsub!(/-\s+/, ' - ') || text
+      def shift_ending_hyphen
+        @text.gsub!(/-\s+/, ' - ')
       end
   end
 end

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -148,13 +148,13 @@ module PragmaticTokenizer
       end
 
       def convert_sgl_quotes!(language)
-        self.replace(if defined?(language::SingleQuotes)
-                       language::SingleQuotes.new
-                           .handle_single_quotes(self)
-                     else
-                       PragmaticTokenizer::Languages::Common::SingleQuotes.new
-                           .handle_single_quotes(self)
-                     end)
+        replace(if defined?(language::SingleQuotes)
+                  language::SingleQuotes.new
+                      .handle_single_quotes(self)
+                else
+                  PragmaticTokenizer::Languages::Common::SingleQuotes.new
+                      .handle_single_quotes(self)
+                end)
       end
 
       def convert_apostrophe_s!

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -89,7 +89,7 @@ module PragmaticTokenizer
         return unless may_shift_colon?
         # Ignore web addresses
         replacement = replacement_for_key(':'.freeze)
-        @text.gsub!(%r{(?<=[http|https]):(?=//)}, replacement)
+        @text.gsub!(%r{(?<=[(https?|ftp)]):(?=//)}, replacement)
         @text.gsub!(/:/o, ' :'.freeze)
         @text.gsub!(/(?<=\s):(?=\#)/, ': '.freeze)
       end

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -36,75 +36,75 @@ module PragmaticTokenizer
 
       # Shift commas off everything but numbers
       def shift_comma!
-        @text.gsub!(/,(?!\d)/o, ' , ')
-        @text.gsub!(/(?<=\D),(?=\S+)/, ' , ')
+        @text.gsub!(/,(?!\d)/o, ' , '.freeze)
+        @text.gsub!(/(?<=\D),(?=\S+)/, ' , '.freeze)
       end
 
       def shift_multiple_dash!
-        @text.gsub!(/--+/o, ' - ')
+        @text.gsub!(/--+/o, ' - '.freeze)
       end
 
       def shift_inverted_question_mark!
-        @text.gsub!(/¿/, ' ¿ ')
+        @text.gsub!(/¿/, ' ¿ '.freeze)
       end
 
       def shift_inverted_exclamation!
-        @text.gsub!(/¡/, ' ¡ ')
+        @text.gsub!(/¡/, ' ¡ '.freeze)
       end
 
       def shift_exclamation!
-        @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! ')
+        @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! '.freeze)
       end
 
       def shift_ellipse!
-        @text.gsub!(/(\.\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
-        @text.gsub!(/(\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
-        @text.gsub!(/(…+)/o) { ' ' + Regexp.last_match(1) + ' ' }
+        @text.gsub!(/(\.\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        @text.gsub!(/(\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        @text.gsub!(/(…+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_no_space_mention!
-        @text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. ')
+        @text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. '.freeze)
       end
 
       def shift_not_equals!
-        @text.gsub!(/≠/, ' ≠ ')
+        @text.gsub!(/≠/, ' ≠ '.freeze)
       end
 
       def shift_special_quotes!
-        @text.gsub!(/«/, ' « ')
-        @text.gsub!(/»/, ' » ')
-        @text.gsub!(/„/, ' „ ')
-        @text.gsub!(/“/, ' “ ')
+        @text.gsub!(/«/, ' « '.freeze)
+        @text.gsub!(/»/, ' » '.freeze)
+        @text.gsub!(/„/, ' „ '.freeze)
+        @text.gsub!(/“/, ' “ '.freeze)
       end
 
       def shift_colon!
         return unless may_shift_colon?
         # Ignore web addresses
-        @text.gsub!(/(?<=[http|https]):(?=\/\/)/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP[":"])
-        @text.gsub!(/:/o, ' :')
-        @text.gsub!(/(?<=\s):(?=\#)/, ': ')
+        @text.gsub!(/(?<=[http|https]):(?=\/\/)/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP[':'.freeze])
+        @text.gsub!(/:/o, ' :'.freeze)
+        @text.gsub!(/(?<=\s):(?=\#)/, ': '.freeze)
       end
 
       def may_shift_colon?
-        return false unless @text.include?(':')
-        partitions = @text.partition(':')
+        return false unless @text.include?(':'.freeze)
+        partitions = @text.partition(':'.freeze)
         partitions.last[0] !~ /\A\d+/ || partitions.first[-1] !~ /\A\d+/
       end
 
       def shift_bracket!
-        @text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' ' }
+        @text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_semicolon!
-        @text.gsub!(/([;])/o) { ' ' + Regexp.last_match(1) + ' ' }
+        @text.gsub!(/([;])/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_percent!
-        @text.gsub!(/(?<=\D)%(?=\d+)/, ' %')
+        @text.gsub!(/(?<=\D)%(?=\d+)/, ' %'.freeze)
       end
 
       def shift_caret!
-        @text.gsub!(/\^/, ' ^ ')
+        @text.gsub!(/\^/, ' ^ '.freeze)
       end
 
       def shift_hashtag!
@@ -112,22 +112,22 @@ module PragmaticTokenizer
       end
 
       def shift_ampersand!
-        @text.gsub!(/\&/, ' & ')
+        @text.gsub!(/\&/, ' & '.freeze)
       end
 
       def shift_vertical_bar!
-        @text.gsub!(/\|/, ' | ')
+        @text.gsub!(/\|/, ' | '.freeze)
       end
 
       def convert_dbl_quotes!
         # Convert left double quotes to special character
-        @text.gsub!(/''(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
-        @text.gsub!(/"(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
-        @text.gsub!(/“(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['“'] + ' ')
+        @text.gsub!(/''(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
+        @text.gsub!(/"(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
+        @text.gsub!(/“(?=.*\w)/o, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['“'.freeze] + ' '.freeze)
         # Convert remaining quotes to special character
-        @text.gsub!(/"/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
-        @text.gsub!(/''/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
-        @text.gsub!(/”/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'] + ' ')
+        @text.gsub!(/"/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
+        @text.gsub!(/''/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'.freeze] + ' '.freeze)
+        @text.gsub!(/”/, ' '.freeze + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'.freeze] + ' '.freeze)
       end
 
       def convert_sgl_quotes!
@@ -139,15 +139,15 @@ module PragmaticTokenizer
       end
 
       def convert_apostrophe_s!
-        @text.gsub!(/\s\u{0301}(?=s(\s|\z))/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['`'])
+        @text.gsub!(/\s\u{0301}(?=s(\s|\z))/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['`'.freeze])
       end
 
       def shift_beginning_hyphen!
-        @text.gsub!(/\s+-/, ' - ')
+        @text.gsub!(/\s+-/, ' - '.freeze)
       end
 
       def shift_ending_hyphen!
-        @text.gsub!(/-\s+/, ' - ')
+        @text.gsub!(/-\s+/, ' - '.freeze)
       end
   end
 end

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -7,77 +7,77 @@ module PragmaticTokenizer
 
     def pre_process(text:)
       @text = text
-      shift_comma
-      shift_multiple_dash
-      shift_upsidedown_question_mark
-      shift_upsidedown_exclamation
-      shift_exclamation
-      shift_ellipse
-      shift_no_space_mention
-      shift_not_equals
-      shift_special_quotes
-      shift_colon
-      shift_bracket
-      shift_semicolon
-      shift_percent
-      shift_caret
-      shift_hashtag
-      shift_ampersand
-      shift_vertical_bar
-      convert_dbl_quotes
-      convert_sgl_quotes
-      convert_apostrophe_s
-      shift_beginning_hyphen
-      shift_ending_hyphen
+      shift_comma!
+      shift_multiple_dash!
+      shift_inverted_question_mark!
+      shift_inverted_exclamation!
+      shift_exclamation!
+      shift_ellipse!
+      shift_no_space_mention!
+      shift_not_equals!
+      shift_special_quotes!
+      shift_colon!
+      shift_bracket!
+      shift_semicolon!
+      shift_percent!
+      shift_caret!
+      shift_hashtag!
+      shift_ampersand!
+      shift_vertical_bar!
+      convert_dbl_quotes!
+      convert_sgl_quotes!
+      convert_apostrophe_s!
+      shift_beginning_hyphen!
+      shift_ending_hyphen!
       @text.squeeze(' ')
     end
 
     private
 
       # Shift commas off everything but numbers
-      def shift_comma
+      def shift_comma!
         @text.gsub!(/,(?!\d)/o, ' , ')
         @text.gsub!(/(?<=\D),(?=\S+)/, ' , ')
       end
 
-      def shift_multiple_dash
+      def shift_multiple_dash!
         @text.gsub!(/--+/o, ' - ')
       end
 
-      def shift_upsidedown_question_mark
+      def shift_inverted_question_mark!
         @text.gsub!(/¿/, ' ¿ ')
       end
 
-      def shift_upsidedown_exclamation
+      def shift_inverted_exclamation!
         @text.gsub!(/¡/, ' ¡ ')
       end
 
-      def shift_exclamation
+      def shift_exclamation!
         @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! ')
       end
 
-      def shift_ellipse
+      def shift_ellipse!
         @text.gsub!(/(\.\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
         @text.gsub!(/(\.\.+)/o) { ' ' + Regexp.last_match(1) + ' ' }
         @text.gsub!(/(…+)/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_no_space_mention
+      def shift_no_space_mention!
         @text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. ')
       end
 
-      def shift_not_equals
+      def shift_not_equals!
         @text.gsub!(/≠/, ' ≠ ')
       end
 
-      def shift_special_quotes
+      def shift_special_quotes!
         @text.gsub!(/«/, ' « ')
         @text.gsub!(/»/, ' » ')
         @text.gsub!(/„/, ' „ ')
         @text.gsub!(/“/, ' “ ')
       end
 
-      def shift_colon
+      def shift_colon!
         return unless may_shift_colon?
         # Ignore web addresses
         @text.gsub!(/(?<=[http|https]):(?=\/\/)/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP[":"])
@@ -91,35 +91,35 @@ module PragmaticTokenizer
         partitions.last[0] !~ /\A\d+/ || partitions.first[-1] !~ /\A\d+/
       end
 
-      def shift_bracket
+      def shift_bracket!
         @text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_semicolon
+      def shift_semicolon!
         @text.gsub!(/([;])/o) { ' ' + Regexp.last_match(1) + ' ' }
       end
 
-      def shift_percent
+      def shift_percent!
         @text.gsub!(/(?<=\D)%(?=\d+)/, ' %')
       end
 
-      def shift_caret
+      def shift_caret!
         @text.gsub!(/\^/, ' ^ ')
       end
 
-      def shift_hashtag
+      def shift_hashtag!
         @text.gsub!(/(?<=\S)(#|＃)(?=\S)/, ' \1\2')
       end
 
-      def shift_ampersand
+      def shift_ampersand!
         @text.gsub!(/\&/, ' & ')
       end
 
-      def shift_vertical_bar
+      def shift_vertical_bar!
         @text.gsub!(/\|/, ' | ')
       end
 
-      def convert_dbl_quotes
+      def convert_dbl_quotes!
         # Convert left double quotes to special character
         @text.gsub!(/''(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
         @text.gsub!(/"(?=.*\w)/o, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['"'] + ' ')
@@ -130,7 +130,7 @@ module PragmaticTokenizer
         @text.gsub!(/”/, ' ' + PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['”'] + ' ')
       end
 
-      def convert_sgl_quotes
+      def convert_sgl_quotes!
         if defined? @language::SingleQuotes
           @language::SingleQuotes.new.handle_single_quotes(@text)
         else
@@ -138,15 +138,15 @@ module PragmaticTokenizer
         end
       end
 
-      def convert_apostrophe_s
+      def convert_apostrophe_s!
         @text.gsub!(/\s\u{0301}(?=s(\s|\z))/, PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP['`'])
       end
 
-      def shift_beginning_hyphen
+      def shift_beginning_hyphen!
         @text.gsub!(/\s+-/, ' - ')
       end
 
-      def shift_ending_hyphen
+      def shift_ending_hyphen!
         @text.gsub!(/-\s+/, ' - ')
       end
   end

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -79,10 +79,7 @@ module PragmaticTokenizer
       end
 
       def shift_special_quotes!
-        @text.gsub!(/«/, ' « '.freeze)
-        @text.gsub!(/»/, ' » '.freeze)
-        @text.gsub!(/„/, ' „ '.freeze)
-        @text.gsub!(/“/, ' “ '.freeze)
+        @text.gsub!(/([«»„“])/, ' \1 ')
       end
 
       def shift_colon!

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -89,7 +89,7 @@ module PragmaticTokenizer
         return unless may_shift_colon?
         # Ignore web addresses
         replacement = replacement_for_key(':'.freeze)
-        @text.gsub!(/(?<=[http|https]):(?=\/\/)/, replacement)
+        @text.gsub!(%r{(?<=[http|https]):(?=//)}, replacement)
         @text.gsub!(/:/o, ' :'.freeze)
         @text.gsub!(/(?<=\s):(?=\#)/, ': '.freeze)
       end

--- a/lib/pragmatic_tokenizer/pre_processor.rb
+++ b/lib/pragmatic_tokenizer/pre_processor.rb
@@ -1,12 +1,7 @@
 module PragmaticTokenizer
-  class PreProcessor
+  module PreProcessor
 
-    def initialize(language: Languages::Common)
-      @language = language
-    end
-
-    def pre_process(text:)
-      @text = text
+    def pre_process(language: Languages::Common)
       shift_comma!
       shift_multiple_dash!
       shift_inverted_question_mark!
@@ -27,102 +22,102 @@ module PragmaticTokenizer
       shift_ampersand!
       shift_vertical_bar!
       convert_dbl_quotes!
-      convert_sgl_quotes!
+      convert_sgl_quotes!(language)
       convert_apostrophe_s!
       shift_beginning_hyphen!
       shift_ending_hyphen!
-      @text.squeeze(' '.freeze)
+      squeeze(' '.freeze)
     end
 
     private
 
       # Shift commas off everything but numbers
       def shift_comma!
-        @text.gsub!(/,(?!\d)/o, ' , '.freeze)
-        @text.gsub!(/(?<=\D),(?=\S+)/, ' , '.freeze)
+        gsub!(/,(?!\d)/o, ' , '.freeze)
+        gsub!(/(?<=\D),(?=\S+)/, ' , '.freeze)
       end
 
       def shift_multiple_dash!
-        @text.gsub!(/--+/o, ' - '.freeze)
+        gsub!(/--+/o, ' - '.freeze)
       end
 
       def shift_inverted_question_mark!
-        @text.gsub!(/¿/, ' ¿ '.freeze)
+        gsub!(/¿/, ' ¿ '.freeze)
       end
 
       def shift_inverted_exclamation!
-        @text.gsub!(/¡/, ' ¡ '.freeze)
+        gsub!(/¡/, ' ¡ '.freeze)
       end
 
       def shift_exclamation!
-        @text.gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! '.freeze)
+        gsub!(/(?<=[a-zA-z])!(?=[a-zA-z])/, ' ! '.freeze)
       end
 
       def shift_horizontal_ellipsis!
-        @text.gsub!(/(…+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        gsub!(/(…+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_ellipse_two_dots!
-        @text.gsub!(/(\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        gsub!(/(\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_ellipse_three_dots!
-        @text.gsub!(/(\.\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        gsub!(/(\.\.\.+)/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_no_space_mention!
-        @text.gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. '.freeze)
+        gsub!(/\.(?=(@|＠)[^\.]+(\s|\z))/, '. '.freeze)
       end
 
       def shift_not_equals!
-        @text.gsub!(/≠/, ' ≠ '.freeze)
+        gsub!(/≠/, ' ≠ '.freeze)
       end
 
       def shift_special_quotes!
-        @text.gsub!(/([«»„“])/, ' \1 ')
+        gsub!(/([«»„“])/, ' \1 ')
       end
 
       def shift_colon!
         return unless may_shift_colon?
         # Ignore web addresses
         replacement = replacement_for_key(':'.freeze)
-        @text.gsub!(%r{(?<=[(https?|ftp)]):(?=//)}, replacement)
-        @text.gsub!(/:/o, ' :'.freeze)
-        @text.gsub!(/(?<=\s):(?=\#)/, ': '.freeze)
+        gsub!(%r{(?<=[(https?|ftp)]):(?=//)}, replacement)
+        gsub!(/:/o, ' :'.freeze)
+        gsub!(/(?<=\s):(?=\#)/, ': '.freeze)
       end
 
       def may_shift_colon?
-        return false unless @text.include?(':'.freeze)
-        partitions = @text.partition(':'.freeze)
+        return false unless include?(':'.freeze)
+        partitions = partition(':'.freeze)
         partitions.last[0] !~ /\A\d+/ || partitions.first[-1] !~ /\A\d+/
       end
 
       def shift_bracket!
-        @text.gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' '.freeze }
+        gsub!(/([\(\[\{\}\]\)])/o) { ' ' + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_semicolon!
-        @text.gsub!(/([;])/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
+        gsub!(/([;])/o) { ' '.freeze + Regexp.last_match(1) + ' '.freeze }
       end
 
       def shift_percent!
-        @text.gsub!(/(?<=\D)%(?=\d+)/, ' %'.freeze)
+        gsub!(/(?<=\D)%(?=\d+)/, ' %'.freeze)
       end
 
       def shift_caret!
-        @text.gsub!(/\^/, ' ^ '.freeze)
+        gsub!(/\^/, ' ^ '.freeze)
       end
 
       def shift_hashtag!
-        @text.gsub!(/(?<=\S)(#|＃)(?=\S)/, ' \1\2')
+        gsub!(/(?<=\S)(#|＃)(?=\S)/, ' \1\2')
       end
 
       def shift_ampersand!
-        @text.gsub!(/\&/, ' & '.freeze)
+        gsub!(/\&/, ' & '.freeze)
       end
 
       def shift_vertical_bar!
-        @text.gsub!(/\|/, ' | '.freeze)
+        gsub!(/\|/, ' | '.freeze)
       end
 
       def convert_dbl_quotes!
@@ -138,7 +133,7 @@ module PragmaticTokenizer
 
       def replace_left_quotes!(style, replacement_key)
         replacement = replacement_for_key(replacement_key)
-        @text.gsub!(/#{style}(?=.*\w)/o, ' '.freeze + replacement + ' '.freeze)
+        gsub!(/#{style}(?=.*\w)/o, ' '.freeze + replacement + ' '.freeze)
       end
 
       def replace_remaining_double_quotes!
@@ -149,28 +144,30 @@ module PragmaticTokenizer
 
       def replace_remaining_quotes!(style, replacement_key)
         replacement = replacement_for_key(replacement_key)
-        @text.gsub!(/#{style}/, ' '.freeze + replacement + ' '.freeze)
+        gsub!(/#{style}/, ' '.freeze + replacement + ' '.freeze)
       end
 
-      def convert_sgl_quotes!
-        @text = if defined?(@language::SingleQuotes)
-                  @language::SingleQuotes.new.handle_single_quotes(@text)
-                else
-                  PragmaticTokenizer::Languages::Common::SingleQuotes.new.handle_single_quotes(@text)
-                end
+      def convert_sgl_quotes!(language)
+        self.replace(if defined?(language::SingleQuotes)
+                       language::SingleQuotes.new
+                           .handle_single_quotes(self)
+                     else
+                       PragmaticTokenizer::Languages::Common::SingleQuotes.new
+                           .handle_single_quotes(self)
+                     end)
       end
 
       def convert_apostrophe_s!
         replacement = replacement_for_key('`'.freeze)
-        @text.gsub!(/\s\u{0301}(?=s(\s|\z))/, replacement)
+        gsub!(/\s\u{0301}(?=s(\s|\z))/, replacement)
       end
 
       def shift_beginning_hyphen!
-        @text.gsub!(/\s+-/, ' - '.freeze)
+        gsub!(/\s+-/, ' - '.freeze)
       end
 
       def shift_ending_hyphen!
-        @text.gsub!(/-\s+/, ' - '.freeze)
+        gsub!(/-\s+/, ' - '.freeze)
       end
 
       def replacement_for_key(replacement_key)

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -114,7 +114,10 @@ module PragmaticTokenizer
       return [] unless text
       tokens = []
       text.scan(/.{,10000}(?=\s|\z)/m).each do |segment|
-        tokens << post_process(PreProcessor.new(language: language_module).pre_process(text: segment))
+        pre_processed = segment
+                            .extend(PragmaticTokenizer::PreProcessor)
+                            .pre_process(language: language_module)
+        tokens << post_process(pre_processed)
       end
       tokens.flatten
     end

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -112,17 +112,19 @@ module PragmaticTokenizer
 
     def tokenize
       return [] unless text
-      tokens = []
-      text.scan(/.{,10000}(?=\s|\z)/m).each do |segment|
-        pre_processed = segment
-                            .extend(PragmaticTokenizer::PreProcessor)
-                            .pre_process(language: language_module)
-        tokens << post_process(pre_processed)
-      end
-      tokens.flatten
+      text
+          .scan(/.{,10000}(?=\s|\z)/m)
+          .map { |segment| post_process(pre_process(segment)) }
+          .flatten
     end
 
     private
+
+      def pre_process(text)
+        text
+            .extend(PragmaticTokenizer::PreProcessor)
+            .pre_process(language: language_module)
+      end
 
       def post_process(text)
         @tokens = PostProcessor.new(text: text, abbreviations: abbreviations).post_process


### PR DESCRIPTION
I've refactored pre_processor.rb (freezing strings to make them reusable, split long methods, extract common code, using an instance variable). There's only one feature addition: I updated a regex from `[http|https]`to `[(https?|ftp)]`.

Additionally, I've converted the class to a module that extends String class. This is slightly faster, results in cleaner code (`gsub!` instead of `@text.gsub!`) and should also allow to write tests specifically for this module. I'm just a bit unsure about passing the language to it, probably this should be handled elsewhere, as I'd prefer this module not needing to know anything about the outside world.

The usage of `.freeze` is questionable, with Ruby 2.3 there will be alternate solutions, but as long as the majority of users are on lower versions this should be considered for gc reasons, even if ugly.