### PR TITLE
lower memory usage by reducing object allocations

### DIFF
--- a/lib/pragmatic_tokenizer/post_processor.rb
+++ b/lib/pragmatic_tokenizer/post_processor.rb
@@ -1,26 +1,43 @@
 module PragmaticTokenizer
   class PostProcessor
 
-    REGEX_SYMBOL         = /[♳ ♴ ♵ ♶ ♷ ♸ ♹ ♺ ⚀ ⚁ ⚂ ⚃ ⚄ ⚅ ☇ ☈ ☉ ☊ ☋ ☌ ☍ ☠ ☢ ☣ ☤ ☥ ☦ ☧ ☀ ☁ ☂ ☃ ☄ ☮ ♔ ♕ ♖ ♗ ♘ ♙ ♚ ⚘ ⚭]/
-    REGEXP_COMMAS        = /^(,|‚)+/
-    REGEXP_SINGLE_QUOTES = /(.+)(’|'|‘|`)$/
-    REGEXP_SLASH         = /^(?!(https?:|www\.))(.*)\/(.*)/
-    REGEXP_QUESTION_MARK = /^(?!(https?:|www\.))(.*)(\?)(.*)/
+    DOT                       = '.'.freeze
+    RANGE_DINGBATS            = '[\u2701-\u27BE]'.freeze # e.g. ✁✎✳❄➾
+    RANGE_VARIATION_SELECTORS = '[\uFE00-\uFE0F]'.freeze # alter the previous character
+    RANGE_FULLWIDTH           = '[\uFF01-\ufF1F]'.freeze # e.g. ！＂＃＇？
+
+    REGEXP_COMMAS        = /^([,‚])+/
+    REGEXP_SINGLE_QUOTES = /(.+)([’'‘`])$/
+    REGEXP_SLASH         = /^(?!(https?:|www\.))(.*)\//
+    REGEXP_QUESTION_MARK = /^(?!(https?:|www\.))(.*)(\?)/
     REGEXP_PLUS_SIGN     = /(.+)\+(.+)/
-    REGEXP_COLON         = /^(\:)(\S{2,})/
-    REGEXP_EMOJI         = /(\u{2744}[\u{FE0E}|\u{FE0F}])/
+    REGEXP_COLON         = /^(:)(\S{2,})/
+    REGEXP_DINGBATS      = /(#{RANGE_DINGBATS}#{RANGE_VARIATION_SELECTORS}*)/
+    REGEXP_ENDING_PUNCT  = /(?<=\S)([#{RANGE_FULLWIDTH}!?]+)$/
+    REGEXP_DOMAIN        = /^((https?:\/\/|)?[a-z0-9]+([\-\.][a-z0-9]+)*\.[a-z]{2,6}(:[0-9]{1,5})?(\/.*)?)$/ix
+    REGEXP_EMAIL         = /\S+[＠@]\S+/
+    REGEXP_DOMAIN_START  = /^(https?:|www\.|[[:alpha:]]\.)/
+    REGEXP_DOMAIN_END    = /\.(com|net|org|edu|gov|mil|int|[[:alpha:]]{2})$/
+    REGEXP_DIGIT         = /[[:digit:]]+/
+    REGEXP_PERIOD1       = /(.*\.)/
+    REGEXP_PERIOD2       = /(\.)/
 
     REGEX_UNIFIED1       = Regexp.union(REGEXP_SLASH,
                                         REGEXP_QUESTION_MARK,
                                         REGEXP_PLUS_SIGN,
                                         REGEXP_COLON,
-                                        REGEXP_EMOJI,
+                                        REGEXP_DINGBATS,
                                         PragmaticTokenizer::Languages::Common::PREFIX_EMOJI_REGEX,
                                         PragmaticTokenizer::Languages::Common::POSTFIX_EMOJI_REGEX)
 
     REGEX_UNIFIED2       = Regexp.union(REGEXP_SINGLE_QUOTES,
                                         REGEXP_COMMAS)
-    REGEXP_UNKNOWN1      = /(?<=\S)([。．！!?？]+)$/
+
+    REGEX_DOMAIN_EMAIL   = Regexp.union(REGEXP_DOMAIN,
+                                        REGEXP_EMAIL)
+
+    REGEX_DOMAIN         = Regexp.union(REGEXP_DOMAIN_START,
+                                        REGEXP_DOMAIN_END)
 
     attr_reader :text, :abbreviations, :downcase
 
@@ -31,19 +48,24 @@ module PragmaticTokenizer
     end
 
     def post_process
-      separate_ending_punctuation(post_process_punctuation)
+      procs.reduce(full_stop_separated_tokens) { |a, e| a.flat_map(&e) }
     end
 
     private
 
-      def post_process_punctuation
-        separated = separate_ending_punctuation(full_stop_separated_tokens)
-        procs     = [unified1, split_unknown_period1, split_unknown_period2, split_emoji]
-        procs.reduce(separated) { |a, e| a.flat_map(&e) }
+      # note: we need to run #separate_ending_punctuation twice. maybe there's a better solution?
+      def procs
+        [
+            separate_ending_punctuation,
+            unified1,
+            split_unknown_period1,
+            split_unknown_period2,
+            separate_ending_punctuation
+        ]
       end
 
-      def separate_ending_punctuation(tokens)
-        tokens.flat_map { |token| token.split(REGEXP_UNKNOWN1) }
+      def separate_ending_punctuation
+        proc { |token| token.split(REGEXP_ENDING_PUNCT) }
       end
 
       def unified1
@@ -51,64 +73,48 @@ module PragmaticTokenizer
       end
 
       def full_stop_separated_tokens
-        FullStopSeparator.new(tokens: split_and_convert_commas_and_quotes, abbreviations: abbreviations, downcase: downcase).separate
+        FullStopSeparator.new(tokens: split_convert_commas_quotes, abbreviations: abbreviations, downcase: downcase).separate
       end
 
-      def split_and_convert_commas_and_quotes
+      def split_convert_commas_quotes
         text
             .split
             .flat_map { |token| token.split(REGEX_UNIFIED2) }
             .flat_map { |token| convert_sym_to_punct(token) }
       end
 
-      def split_emoji
-        proc { |token| (token =~ /(\A|\S)\u{2744}[^\u{FE0E}|\u{FE0F}]/) ? token.split(/(\u{2744})/) : token }
-      end
-
       def split_unknown_period1
-        proc { |token| unknown_period1?(token) ? token.split(/(.*\.)/) : token }
+        proc { |token| unknown_period1?(token) ? token.split(REGEXP_PERIOD1) : token }
       end
 
       def split_unknown_period2
-        proc { |token| unknown_period2?(token) ? token.split(/(\.)/) : token }
+        proc { |token| unknown_period2?(token) ? token.split(REGEXP_PERIOD2) : token }
       end
 
       def unknown_period1?(token)
-        token.include?(".") &&
-            token !~ /(http|https|www)(\.|:)/ &&
+        token.include?(DOT) &&
             token.length > 1 &&
-            token !~ /(\s+|\A)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}(:[0-9]{1,5})?(\/.*)?/ix &&
-            token !~ /\S+(＠|@)\S+/ &&
+            token !~ REGEX_DOMAIN_EMAIL &&
             abbreviations.include?(extract_abbreviation(token))
       end
 
       def unknown_period2?(token)
-        token.include?(".") &&
-            token !~ /(http|https|www)(\.|:)/ &&
-            token !~ /\.(com|net|org|edu|gov|mil|int)/ &&
-            token !~ /\.[a-zA-Z]{2}(\s|\z)/ &&
-            token.length > 2 &&
-            token !~ /\A[a-zA-Z]{1}\./ &&
-            token.count(".") == 1 &&
-            token !~ /\d+/ &&
-            !abbreviations.include?(extract_abbreviation(token)) &&
-            token !~ /\S+(＠|@)\S+/
+        token.include?(DOT) &&
+            token !~ REGEX_DOMAIN &&
+            token !~ REGEXP_DIGIT &&
+            token.count(DOT) == 1 &&
+            !abbreviations.include?(extract_abbreviation(token))
       end
 
       def extract_abbreviation(token)
-        before_first_dot = token[0, token.index('.'.freeze)]
+        before_first_dot = token[0, token.index(DOT)]
         downcase ? before_first_dot : Unicode.downcase(before_first_dot)
       end
 
       def convert_sym_to_punct(token)
-        symbol_matches = REGEX_SYMBOL.match(token)
-        if symbol_matches.nil?
-          token
-        else
-          pattern     = symbol_matches[0]
-          replacement = PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP.key(pattern)
-          token.gsub!(pattern, replacement)
-        end
+        PragmaticTokenizer::Languages::Common::PUNCTUATION_MAP
+            .each { |pattern, replacement| break if token.sub!(replacement, pattern) }
+        token
       end
 
   end

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -150,7 +150,7 @@ module PragmaticTokenizer
 
     def tokenize(text)
       return [] unless text
-      raise "In Pragmatic Tokenizer text must be a String" unless text.class == String
+      raise "In PragmaticTokenizer text must be a String or subclass of String" unless text.class <= String
       CGI.unescapeHTML(text)
           .scan(REGEXP_CHUNK_STRING)
           .flat_map { |segment| post_process(pre_process(segment)) }

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -64,7 +64,7 @@ module PragmaticTokenizer
     REGEXP_NO_NUMBERS          = /\A\D+\z/
     REGEXP_NUMBER              = /\D*\d+\d*/
     REGEXP_CONSECUTIVE_DOTS    = /\A\.{2,}\z/
-    REGEXP_CHUNK_STRING        = /.{,10000}(?=\s|\z)/m
+    REGEXP_CHUNK_STRING        = /\S.{1,10000}(?!\S)/m
 
     # @param [Hash] opts optional arguments
 


### PR DESCRIPTION
These commits reduce object allocations by reusing regexes, using string modification without regex where possible and using flat_map.

Additionally regexes were simplified (all tests still pass), code readability has been improved, and unnecessary loops are prevented. 

Finally, PragmaticTokenizer can now also handle instances of `PragmaticSegmenter::Text`, which is a workaround for: https://github.com/diasks2/pragmatic_segmenter/issues/38

I only focused on the methods that caused the highest amount of allocations in my tests, meaning these are only the low hanging fruits, more could certainly be done. I'm using PragmaticTokenizer in a worker which usually steadily climbed from 300MB to ~400MB memory usage within a day (heroku does daily restarts), and this branch shows a constant hover at around 350MB on the first day of running in production.

Not a focus in this branch was optimizing for speed. There's probably a few things that could be done with extensive benchmarking (e.g. shuffling the order of checks which are chained with `&&`, keeping the fastest upfront).