### PR TITLE
& symbol and URL's downcase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 2.2.4
+  - 2.7.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pragmatic Tokenizer
 
-[![Gem Version](https://badge.fury.io/rb/pragmatic_tokenizer.svg)](https://badge.fury.io/rb/pragmatic_tokenizer) [![Build Status](https://travis-ci.org/diasks2/pragmatic_tokenizer.png)](https://travis-ci.org/diasks2/pragmatic_tokenizer) [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](https://github.com/diasks2/pragmatic_tokenizer/blob/master/LICENSE.txt)
+[![Gem Version](https://badge.fury.io/rb/pragmatic_tokenizer.svg)](https://badge.fury.io/rb/pragmatic_tokenizer) [![Build Status](https://travis-ci.org/giovannelli/pragmatic_tokenizer.png)](https://travis-ci.org/giovannelli/pragmatic_tokenizer) [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](https://github.com/diasks2/pragmatic_tokenizer/blob/master/LICENSE.txt)
 
 Pragmatic Tokenizer is a multilingual tokenizer to split a string into tokens.
 

--- a/lib/pragmatic_tokenizer/post_processor.rb
+++ b/lib/pragmatic_tokenizer/post_processor.rb
@@ -17,6 +17,7 @@ module PragmaticTokenizer
       text
           .split
           .map      { |token| convert_sym_to_punct(token) }
+          .flat_map { |token| !token.include?("://") && @downcase ? Unicode.downcase(token) : token }
           .flat_map { |token| token.split(Regex::COMMAS_OR_PUNCTUATION) }
           .flat_map { |token| token.split(Regex::VARIOUS) }
           .flat_map { |token| token.split(Regex::ENDS_WITH_PUNCTUATION2) }

--- a/lib/pragmatic_tokenizer/regex.rb
+++ b/lib/pragmatic_tokenizer/regex.rb
@@ -61,7 +61,7 @@ module PragmaticTokenizer
     QUESTION_MARK_NOT_URL         = /#{NOT_URL.source}(\?)/
     # Should we change specs and also capture "/", just like we capture ":" and "?"
     SLASH_NOT_URL                 = /#{NOT_URL.source}\//
-    SHIFT_BOUNDARY_CHARACTERS     = /([;^&|…«»„“¿¡≠]+)/
+    SHIFT_BOUNDARY_CHARACTERS     = /([;^|…«»„“¿¡≠]+)/
     MULTIPLE_DOTS                 = /(\.{2,})/ # we keep all dashes
     MULTIPLE_DASHES               = /(-){2,}/ # we only keep first dash
     BRACKET                       = /([{}()\[\]])/

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -112,9 +112,8 @@ module PragmaticTokenizer
 
       def process_segment(segment)
         pre_processed = pre_process(segment)
-        cased_segment = chosen_case(pre_processed)
-        @tokens       = PostProcessor.new(text: cased_segment, abbreviations: @abbreviations, downcase: @downcase).call
-        post_process_tokens
+        @tokens       = PostProcessor.new(text: pre_processed, abbreviations: @abbreviations, downcase: @downcase).call
+        post_process_tokens.map { |token| token.include?("://") ? token : chosen_case(token) }
       end
 
       def pre_process(segment)

--- a/lib/pragmatic_tokenizer/tokenizer.rb
+++ b/lib/pragmatic_tokenizer/tokenizer.rb
@@ -111,10 +111,12 @@ module PragmaticTokenizer
     private
 
       def process_segment(segment)
-        pre_processed = pre_process(segment)
-        @tokens       = PostProcessor.new(text: pre_processed, abbreviations: @abbreviations, downcase: @downcase).call
-        post_process_tokens.map { |token| token.include?("://") ? token : chosen_case(token) }
-      end
+        pre_processed = pre_process(segment)        
+        @tokens       = PostProcessor.new(text: pre_processed, abbreviations: @abbreviations, downcase: @downcase).call	        
+        post_process_tokens
+     end
+
+
 
       def pre_process(segment)
         segment
@@ -253,10 +255,6 @@ module PragmaticTokenizer
         return token if token =~ Regex::ONLY_HASHTAG_MENTION
         return token if token =~ Regex::DOMAIN_OR_EMAIL
         token.split(Regex::HYPHEN_OR_UNDERSCORE)
-      end
-
-      def chosen_case(text)
-        @downcase ? Unicode.downcase(text) : text
       end
 
       def inverse_case(token)

--- a/pragmatic_tokenizer.gemspec
+++ b/pragmatic_tokenizer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "unicode"
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "> 1.9"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "stackprof"

--- a/spec/languages/deutsch_spec.rb
+++ b/spec/languages/deutsch_spec.rb
@@ -38,7 +38,7 @@ describe PragmaticTokenizer do
       text = "Charlie Hebdo backlash over 'racist' Alan Kurdi cartoon - https://t.co/J8N2ylVV3w"
       expect(PragmaticTokenizer::Tokenizer.new(
           language: 'de'
-      ).tokenize(text)).to eq(["charlie", "hebdo", "backlash", "over", "'", "racist", "'", "alan", "kurdi", "cartoon", "-", "https://t.co/j8n2ylvv3w"])
+      ).tokenize(text)).to eq(["charlie", "hebdo", "backlash", "over", "'", "racist", "'", "alan", "kurdi", "cartoon", "-", "https://t.co/J8N2ylVV3w"])
     end
 
     it 'handles words with a slash 1' do

--- a/spec/languages/english_spec.rb
+++ b/spec/languages/english_spec.rb
@@ -679,7 +679,7 @@ describe PragmaticTokenizer do
           pt = PragmaticTokenizer::Tokenizer.new(
               clean: true
           )
-          expect(pt.tokenize(text)).to eq(["you", "&", "me"])
+          expect(pt.tokenize(text)).to eq(["you&me"])
         end
       end
 
@@ -1354,7 +1354,7 @@ describe PragmaticTokenizer do
               clean:       true,
               punctuation: :none
           )
-          expect(pt.tokenize(text)).to eq(%w(you me))
+          expect(pt.tokenize(text)).to eq(%w(you&me))
         end
 
         it 'cleans percent signs not related to numbers' do


### PR DESCRIPTION
Hi,
related to the issue #33 I've changed the [post_processor.rb ](https://github.com/giovannelli/pragmatic_tokenizer/blob/a5dc3cde15553f04a084f1b91aeeb2c6e05aca13/lib/pragmatic_tokenizer/post_processor.rb) to skip URL's down case.
I also changed the tokenisation for the symbol "&", now you&me or m&m's are tokenised as a single token. 
Could it be a configurable behaviour?

Best